### PR TITLE
Support complex interval for MySQL

### DIFF
--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -280,7 +280,7 @@ class Formatter:
         )
 
     def _interval(self, json):
-        return 'INTERVAL {0} {1}'.format(json[0], json[1].upper())
+        return 'INTERVAL {0} {1}'.format(self.dispatch(json[0]), json[1].upper())
 
     def _cast(self, json):
         return 'CAST({0} AS {1})'.format(self.dispatch(json[0]), json[1].upper())

--- a/moz_sql_parser/sql_parser.py
+++ b/moz_sql_parser/sql_parser.py
@@ -315,7 +315,7 @@ def _or(values):
 
 interval = (
     Keyword("interval", caseless=True).suppress().setDebugActions(*debug) +
-    (realNum | intNum)("count").setDebugActions(*debug) +
+    expr("count") +
     _or([Keyword(d, caseless=True)("duration") for d in durations])
 ).addParseAction(to_interval_call).setDebugActions(*debug)
 

--- a/tests/test_format_and_parse.py
+++ b/tests/test_format_and_parse.py
@@ -1141,5 +1141,4 @@ from benn.college_football_players
             {"curdate": {}}, {"interval": [{"sub": [{"dayofweek": {"curdate": {}}}, 1]}, "day"]}
         ]}}}
         self.assertEqual(parsed_sql, expected_json)
-
-        assert format(parsed_sql).lower() == sql.lower()
+        self.verify_formatting(sql, expected_json)

--- a/tests/test_format_and_parse.py
+++ b/tests/test_format_and_parse.py
@@ -1133,3 +1133,13 @@ from benn.college_football_players
 
         self.assertEqual(expected_sql, format(parse(expected_sql)))
         self.verify_formatting(expected_sql, expected_json)
+
+    def test_198_complex_interval(self):
+        sql = "select CURDATE() - interval DAYOFWEEK(CURDATE()) - 1 DAY"
+        parsed_sql = parse(sql)
+        expected_json = {"select": {"value": {"sub": [
+            {"curdate": {}}, {"interval": [{"sub": [{"dayofweek": {"curdate": {}}}, 1]}, "day"]}
+        ]}}}
+        self.assertEqual(parsed_sql, expected_json)
+
+        assert format(parsed_sql).lower() == sql.lower()


### PR DESCRIPTION
The syntax of INTERVAL in MySQL is `INTERVAL expr unit`, with `expr` could be any expression. So in order to support MySQL INTERVAL, I treat the `count` parameter as an expression.
One problem with this library is it doesn't have a mechanism to support separate DBMS dialect (MySQL, Postgresql, Bigquery), I think we need to figure it out if we want to support multiple databases

MySQL reference: https://dev.mysql.com/doc/refman/8.0/en/expressions.html#temporal-intervals